### PR TITLE
Add structured landing page components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,66 +1,23 @@
-import Image from "next/image";
+import Header from '@/components/Header';
+import Hero from '@/components/Hero';
+import About from '@/components/About';
+import Services from '@/components/Services';
+import CallToAction from '@/components/CallToAction';
+import ContactForm from '@/components/ContactForm';
+import Footer from '@/components/Footer';
 
 export default function Home() {
   return (
-    <div className="container">
-      <nav className="navbar">
-        <Image src="/next.svg" alt="Logo" width={120} height={30} />
-        <div className="nav-links">
-          <a href="#">Home</a>
-          <a href="#">About</a>
-          <a href="#">Contact</a>
-        </div>
-      </nav>
-
-      <section className="hero">
-        <div className="hero-content">
-          <h1>Welcome to Next.js</h1>
-          <p>Build modern web apps with ease.</p>
-          <div className="hero-buttons">
-            <button className="button button-primary">Get Started</button>
-            <button className="button button-secondary">Learn More</button>
-          </div>
-        </div>
-      </section>
-
-      <section className="features">
-        <h2 className="section-title">Our Features</h2>
-        <p className="section-subtitle">Everything you need</p>
-        <div className="card-grid">
-          <div className="card">
-            <Image src="/globe.svg" alt="Global" width={48} height={48} />
-            <h3 className="card-title">Global Reach</h3>
-            <p className="card-text">Serve users anywhere in the world.</p>
-          </div>
-          <div className="card">
-            <Image src="/file.svg" alt="Docs" width={48} height={48} />
-            <h3 className="card-title">Documentation</h3>
-            <p className="card-text">Comprehensive guides and examples.</p>
-          </div>
-          <div className="card">
-            <Image src="/window.svg" alt="Components" width={48} height={48} />
-            <h3 className="card-title">Components</h3>
-            <p className="card-text">Reusable UI building blocks.</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="contact">
-        <h2 className="section-title">Get in Touch</h2>
-        <form className="contact-form">
-          <div className="form-group">
-            <input className="input" type="text" placeholder="Name" />
-          </div>
-          <div className="form-group">
-            <input className="input" type="email" placeholder="Email" />
-          </div>
-          <button type="submit" className="button button-primary">Submit</button>
-        </form>
-      </section>
-
-      <footer className="footer">
-        <p className="footer-bottom">© 2024 Example Co.</p>
-      </footer>
-    </div>
+    <>
+      <Header />
+      <main className="space-y-24 md:space-y-32">
+        <Hero />
+        <About />
+        <Services />
+        <CallToAction />
+        <ContactForm />
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,19 @@
+import SectionHeading from './SectionHeading';
+import Image from 'next/image';
+import aboutImage from '@/assets/frames/Frame 20115.png';
+
+export default function About() {
+  return (
+    <section id="about" className="container md:grid md:grid-cols-2 gap-16 py-24 items-center">
+      <div className="relative order-2 md:order-1">
+        <SectionHeading label="About Us" title="Turning ideas into successful startups" align="left" />
+        <p className="mt-6 max-w-md text-neutral-600">
+          We provide mentorship, resources and a vibrant community to help budding entrepreneurs turn concepts into thriving businesses.
+        </p>
+      </div>
+      <div className="order-1 md:order-2 flex justify-center">
+        <Image src={aboutImage} alt="about" width={400} height={300} className="rounded-xl" />
+      </div>
+    </section>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,17 @@
+"use client"
+import { ReactNode } from 'react';
+
+interface ButtonProps {
+  children: ReactNode;
+  variant?: 'primary' | 'secondary';
+  className?: string;
+}
+
+export default function Button({ children, variant = 'primary', className = '' }: ButtonProps) {
+  const base = 'rounded-md px-6 py-3 font-semibold text-sm transition';
+  const styles =
+    variant === 'primary'
+      ? 'bg-primary text-white hover:bg-primary/90'
+      : 'border border-primary text-primary hover:bg-pale-gold';
+  return <button className={`${base} ${styles} ${className}`}>{children}</button>;
+}

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -1,0 +1,15 @@
+import Button from './Button';
+
+export default function CallToAction() {
+  return (
+    <section className="border-y border-primary bg-offwhite py-12" id="cta">
+      <div className="container grid md:grid-cols-2 items-center gap-8">
+        <h2 className="text-3xl font-bold font-poppins">Are you ready to take the next step?</h2>
+        <div className="space-y-4 md:text-right">
+          <p>Join our community of visionaries shaping the future today.</p>
+          <Button className="w-full md:w-auto">Get Started</Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,21 @@
+"use client"
+import SectionHeading from './SectionHeading';
+import Button from './Button';
+
+export default function ContactForm() {
+  return (
+    <section id="contact" className="container py-24 space-y-12">
+      <SectionHeading label="Contact Us" title="Connect with us to turn your ideas into reality" />
+      <form className="grid gap-6 md:grid-cols-2" onSubmit={(e) => e.preventDefault()}>
+        <input className="border p-3 rounded col-span-1" placeholder="First Name" />
+        <input className="border p-3 rounded col-span-1" placeholder="Last Name" />
+        <input className="border p-3 rounded md:col-span-2" type="email" placeholder="Email" />
+        <input className="border p-3 rounded md:col-span-2" placeholder="Phone Number" />
+        <textarea className="border p-3 rounded md:col-span-2" placeholder="Message" rows={4}></textarea>
+        <div className="md:col-span-2">
+          <Button className="w-full">Submit</Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function Footer() {
+  return (
+    <footer className="bg-pale-gold/50 py-12 mt-24">
+      <div className="container grid md:grid-cols-3 gap-8">
+        <div>
+          <h3 className="font-bold mb-4">Get Started</h3>
+          <p className="max-w-sm text-sm">At Get Started, we are more than just a business incubator.</p>
+        </div>
+        <div className="space-y-2">
+          <h3 className="font-bold">Quick Links</h3>
+          <ul className="space-y-1">
+            <li><Link href="#">Home</Link></li>
+            <li><Link href="#about">About Us</Link></li>
+            <li><Link href="#services">Our Services</Link></li>
+            <li><Link href="#contact">Contact</Link></li>
+          </ul>
+        </div>
+        <div className="flex gap-4 items-start">
+          <Image src="/next.svg" alt="LinkedIn" width={32} height={32} className="bg-primary rounded-full p-1" />
+          <Image src="/next.svg" alt="Twitter" width={32} height={32} className="bg-primary rounded-full p-1" />
+        </div>
+      </div>
+      <div className="text-center text-sm mt-8 border-t border-pale-gold pt-4">
+        All rights reserved | GetStarted 2025
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import Button from './Button';
+
+export default function Header() {
+  return (
+    <header className="sticky top-0 backdrop-blur bg-white/80 z-50">
+      <div className="container flex items-center justify-between h-16">
+        <span className="font-bold text-lg">Get started</span>
+        <nav className="hidden md:flex gap-6 font-medium">
+          <Link href="#">Home</Link>
+          <Link href="#about">About Us</Link>
+          <Link href="#services">Our Services</Link>
+          <Link href="#contact">Contact</Link>
+        </nav>
+        <Button className="hidden md:inline-flex" variant="primary">Contact Us</Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+import Button from './Button';
+import heroImage from '@/assets/frames/Frame 20112.png';
+
+export default function Hero() {
+  return (
+    <section className="container grid md:grid-cols-2 gap-8 py-24 items-center" id="hero">
+      <div className="space-y-6">
+        <h1 className="text-4xl md:text-5xl font-bold leading-tight font-poppins">
+          Your Partner in Turning
+          <br />Ideas into Future-Shaping
+          <br />Startup
+        </h1>
+        <p className="max-w-md text-lg">We help founders bring innovative ideas to life with expert guidance and resources.</p>
+        <div className="flex gap-4">
+          <Button>Get Started</Button>
+          <Button variant="secondary">Learn More</Button>
+        </div>
+      </div>
+      <div className="relative h-80 md:h-[500px]">
+        <Image src={heroImage} alt="device" fill className="object-contain rounded-xl shadow-lg" />
+      </div>
+    </section>
+  );
+}

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -1,0 +1,15 @@
+interface SectionHeadingProps {
+  label: string;
+  title: string;
+  align?: 'left' | 'center';
+}
+
+export default function SectionHeading({ label, title, align = 'center' }: SectionHeadingProps) {
+  const alignClass = align === 'center' ? 'text-center' : 'text-left';
+  return (
+    <div className={`space-y-2 ${alignClass}`}> 
+      <span className="uppercase text-primary tracking-wider text-sm font-semibold">{label}</span>
+      <h2 className="text-3xl md:text-4xl font-bold font-poppins">{title}</h2>
+    </div>
+  );
+}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,0 +1,28 @@
+import SectionHeading from './SectionHeading';
+import Image from 'next/image';
+import serviceIcon from '@/assets/icons/icon 100.png';
+
+const services = [
+  { icon: serviceIcon, title: 'Launch', desc: 'From idea to market, we guide you at every step.' },
+  { icon: serviceIcon, title: 'Scale', desc: 'Grow your startup with expert mentorship.' },
+  { icon: serviceIcon, title: 'Network', desc: 'Connect with investors and peers around the globe.' },
+];
+
+export default function Services() {
+  return (
+    <section id="services" className="container py-24 space-y-12">
+      <SectionHeading label="What we do" title="Perfect Solution for Your Business" />
+      <div className="grid gap-8 md:grid-cols-3">
+        {services.map((s) => (
+          <div key={s.title} className="rounded-xl shadow p-6 text-center space-y-4 hover:-translate-y-1 transition">
+            <div className="w-16 h-16 mx-auto bg-pale-gold flex items-center justify-center rounded">
+              <Image src={s.icon} alt="icon" width={32} height={32} />
+            </div>
+            <h3 className="text-xl font-semibold">{s.title}</h3>
+            <p className="text-sm text-neutral-700">{s.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: '1rem',
+      screens: {
+        lg: '1140px',
+      },
+    },
+    extend: {
+      colors: {
+        primary: '#947424',
+        'pale-gold': '#E8E1CF',
+        offwhite: '#FCFCF9',
+      },
+      fontFamily: {
+        poppins: ['var(--font-poppins)', 'sans-serif'],
+        inter: ['var(--font-inter)', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up Tailwind config with brand colors and fonts
- build common UI components and page sections
- compose the home page using new components
- swap placeholder screenshots for actual design assets

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68681b1e48048332a9b4bf4b75bf91f5